### PR TITLE
feat(builder): include NewColumnsValues func

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -21,6 +21,7 @@ type DDLSQLBuilder interface {
 // ColumnsValues represents a mapping between column names and their corresponding values.
 type ColumnsValues map[string]any
 
+// NewColumnsValues helps to initialize a pointer for ColumnsValues map​, with given columns and values slices params.
 func NewColumnsValues(columns []string, values []any) (*ColumnsValues, error) {
 	if len(columns) != len(values) {
 		return nil, failedToGetColumnsValues(errors.New("columns len must be equal to values len"))

--- a/builder.go
+++ b/builder.go
@@ -2,8 +2,10 @@ package ormshift
 
 import (
 	"database/sql"
+	"errors"
 	"slices"
 
+	"github.com/ordershift/ormshift/errs"
 	"github.com/ordershift/ormshift/schema"
 )
 
@@ -18,6 +20,21 @@ type DDLSQLBuilder interface {
 
 // ColumnsValues represents a mapping between column names and their corresponding values.
 type ColumnsValues map[string]any
+
+func NewColumnsValues(columns []string, values []any) (*ColumnsValues, error) {
+	if len(columns) != len(values) {
+		return nil, failedToGetColumnsValues(errors.New("columns len must be equal to values len"))
+	}
+	cv := ColumnsValues{}
+	for i, c := range columns {
+		cv[c] = values[i]
+	}
+	return &cv, nil
+}
+
+func failedToGetColumnsValues(err error) error {
+	return errs.FailedTo("get columns values", err)
+}
 
 // ToNamedArgs transforms ColumnsValues to a sql.NamedArg array ordered by name, e.g.:
 //

--- a/builder_test.go
+++ b/builder_test.go
@@ -26,3 +26,25 @@ func TestColumnsValuesToColumns(t *testing.T) {
 	testutils.AssertEqualWithLabel(t, columns[0], "id", "ColumnsValues.ToColumns[0]")
 	testutils.AssertEqualWithLabel(t, columns[1], "sku", "ColumnsValues.ToColumns[1]")
 }
+
+func TestNewColumnsValues(t *testing.T) {
+	columns := []string{"id", "sku"}
+	values := []any{1, "ABC1234"}
+	cv, err := ormshift.NewColumnsValues(columns, values)
+	if !testutils.AssertNotNilResultAndNilError(t, cv, err, "ormshift.NewColumnsValues") {
+		return
+	}
+	testutils.AssertEqualWithLabel(t, 2, len(*cv), "len(ColumnsValues)")
+	testutils.AssertEqualWithLabel(t, (*cv)["id"], 1, "id")
+	testutils.AssertEqualWithLabel(t, (*cv)["sku"], "ABC1234", "sku")
+}
+
+func TestNewColumnsValuesFailsWhenIncompatibleLengths(t *testing.T) {
+	columns := []string{"id", "sku"}
+	values := []any{1}
+	cv, err := ormshift.NewColumnsValues(columns, values)
+	if !testutils.AssertNilResultAndNotNilError(t, cv, err, "ormshift.NewColumnsValues") {
+		return
+	}
+	testutils.AssertErrorMessage(t, "failed to get columns values: columns len must be equal to values len", err, "ormshift.NewColumnsValues")
+}


### PR DESCRIPTION
NewColumnsValues ​​is a function that, given column slices and values, helps initialize a pointer to the ColumnsValues ​​structure.